### PR TITLE
feat: add `CAN_CERTIFY` and `CAN_SIGN` PGP flags to signature

### DIFF
--- a/src/main/kotlin/me/stojan/kmspgp/crypto/PGP.kt
+++ b/src/main/kotlin/me/stojan/kmspgp/crypto/PGP.kt
@@ -124,6 +124,8 @@ object PGP {
                 // https://datatracker.ietf.org/doc/html/rfc4880#section-5.2.3.21
                 setFeature(false, 0x01 or 0x02)
 
+		setKeyFlags(false, 0x03)
+
                 pubRes.signingAlgorithms().map {
                     when (it) {
                         SigningAlgorithmSpec.ECDSA_SHA_256,


### PR DESCRIPTION
GitHub expects the signing flag to be set for the GPG key used, otherwise it will mark the commit as unverified.

`0x03` is used to attach `CAN_CERTIFY` and `CAN_SIGN` flags (cf. [PGPKeyFlags](https://javadoc.io/static/org.bouncycastle/bcpg-jdk15on/1.68/org/bouncycastle/openpgp/PGPKeyFlags.html)).
